### PR TITLE
Fix uploading files with non-ASCII chars in name to Azure blob store

### DIFF
--- a/src/Webinex.Flippo.All/Package.props
+++ b/src/Webinex.Flippo.All/Package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <Title>Webinex Flippo</Title>
-        <PackageVersion>1.1.1</PackageVersion>
+        <PackageVersion>1.2.0</PackageVersion>
         <Authors>Webinex Dev</Authors>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Webinex.Flippo.All/Webinex.Flippo.All.csproj
+++ b/src/Webinex.Flippo.All/Webinex.Flippo.All.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)/Package.props" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>Webinex.Flippo.All</PackageId>
     <RootNamespace>Webinex.Flippo.All</RootNamespace>
   </PropertyGroup>

--- a/src/Webinex.Flippo.AspNetCore/FlippoControllerBase.cs
+++ b/src/Webinex.Flippo.AspNetCore/FlippoControllerBase.cs
@@ -171,7 +171,7 @@ namespace Webinex.Flippo.AspNetCore
                 return false;
             }
 
-            Response.Headers.Add(HeaderNames.ETag, etagResult.Payload.ToString());
+            Response.Headers[HeaderNames.ETag] = etagResult.Payload.ToString();
             return true;
         }
 
@@ -188,7 +188,7 @@ namespace Webinex.Flippo.AspNetCore
                 return false;
             }
 
-            Response.Headers.Add(HeaderNames.CacheControl, cacheControlHeaderValueResult.Payload.ToString());
+            Response.Headers[HeaderNames.CacheControl] = cacheControlHeaderValueResult.Payload.ToString();
             return true;
         }
 
@@ -196,7 +196,7 @@ namespace Webinex.Flippo.AspNetCore
         {
             var contentDisposition = new ContentDisposition
                 { Inline = true, FileName = content.FileName, Size = content.Stream.Length }.ToString();
-            Response.Headers.Add(HeaderNames.ContentDisposition, contentDisposition);
+            Response.Headers[HeaderNames.ContentDisposition] = contentDisposition;
         }
 
         protected virtual IAuthorizationService AuthorizationService =>

--- a/src/Webinex.Flippo.AspNetCore/Webinex.Flippo.AspNetCore.csproj
+++ b/src/Webinex.Flippo.AspNetCore/Webinex.Flippo.AspNetCore.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)/../Webinex.Flippo.All/Package.props" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>Webinex.Flippo.AspNetCore</PackageId>
     <RootNamespace>Webinex.Flippo.AspNetCore</RootNamespace>
   </PropertyGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
     <PackageReference Include="Webinex.Coded.AspNetCore" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/Webinex.Flippo.AzureBlob/AzureBlobStore.cs
+++ b/src/Webinex.Flippo.AzureBlob/AzureBlobStore.cs
@@ -126,8 +126,8 @@ namespace Webinex.Flippo.AzureBlob
             {
                 return new Dictionary<string, string>
                 {
-                    [nameof(FileName)] = FileName,
-                    [nameof(MimeType)] = MimeType,
+                    [nameof(FileName)] = EscapeHeader(FileName),
+                    [nameof(MimeType)] = EscapeHeader(MimeType),
                 };
             }
 
@@ -139,12 +139,22 @@ namespace Webinex.Flippo.AzureBlob
                 metadata.TryGetValue(nameof(FileName), out var fileName);
                 metadata.TryGetValue(nameof(MimeType), out var mimeType);
 
-                return new Metadata { FileName = fileName, MimeType = mimeType };
+                return new Metadata { FileName = UnescapeHeader(fileName), MimeType = UnescapeHeader(mimeType) };
             }
 
             public static Metadata From(FlippoStoreBlobArgs args)
             {
                 return new Metadata { FileName = args.FileName, MimeType = args.MimeType };
+            }
+
+            private static string EscapeHeader(string value)
+            {
+                return Uri.EscapeDataString(value);
+            }
+
+            private static string UnescapeHeader(string value)
+            {
+                return Uri.UnescapeDataString(value);
             }
         }
     }

--- a/src/Webinex.Flippo.AzureBlob/Webinex.Flippo.AzureBlob.csproj
+++ b/src/Webinex.Flippo.AzureBlob/Webinex.Flippo.AzureBlob.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Webinex.Flippo.Example/Webinex.Flippo.Example.csproj
+++ b/src/Webinex.Flippo.Example/Webinex.Flippo.Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/Webinex.Flippo/Webinex.Flippo.csproj
+++ b/src/Webinex.Flippo/Webinex.Flippo.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.109",
+    "version": "8.0.409",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-net/issues/10629
Azure blob store client sends metadata as HTTP headers which does not allow non-ASCII characters, escape metadata values to fix the issue
